### PR TITLE
Accept Uint8Array in addition to Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@
 /**
  * Check if a Buffer is utf-8
  *
- * @param {Buffer} buf
+ * @param {Uint8Array} buf
  * @returns {boolean}
  */
 function isUtf8(buf) {


### PR DESCRIPTION
Buffer is a subclass of Uint8Array, so accepting Uint8Array will automatically also accept Buffer. With this patch in place you can use this library with a plain Uint8Array, e.g. in the browser.